### PR TITLE
Initial implementation for the JVM and JavaScript.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: scala
+
+scala:
+  - 2.10.7
+  - 2.11.12
+  - 2.12.6
+  - 2.13.0-M4
+jdk:
+  - oraclejdk8
+env:
+  matrix:
+    - SCALAJS_VERSION=
+    - SCALAJS_VERSION=0.6.23
+    - SCALAJS_VERSION=1.0.0-M3
+
+matrix:
+  exclude:
+    # 2.10 is not supported in Scala.js 1.x
+    - scala: 2.10.7
+      env: SCALAJS_VERSION=1.0.0-M3
+
+    # 2.13.0-M4 is not available in Scala.js 1.0.0-M3
+    - scala: 2.13.0-M4
+      env: SCALAJS_VERSION=1.0.0-M3
+
+    # Scala.js 1.0.0-M3 does not have the fix for #3227 yet
+    - scala: 2.11.12
+      env: SCALAJS_VERSION=1.0.0-M3
+
+script:
+  - |
+    if [ "$SCALAJS_VERSION" = "" ]; then
+      PROJECT_NAME="reflectJVM"
+    else
+      PROJECT_NAME="reflectJS"
+    fi
+  - sbt ++$TRAVIS_SCALA_VERSION $PROJECT_NAME/test
+  - sbt ++$TRAVIS_SCALA_VERSION $PROJECT_NAME/doc
+
+before_cache:
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
+cache:
+  directories:
+  - $HOME/.ivy2/cache
+  - $HOME/.sbt/boot
+  - $HOME/.sbt/launchers

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,9 @@ lazy val reflect = crossProject(JSPlatform, JVMPlatform)
     scalacOptions in (Compile, doc) -= "-Xfatal-warnings",
   )
   .jvmSettings(
+    // Macros
+    libraryDependencies += scalaOrganization.value % "scala-reflect" % scalaVersion.value,
+
     // Speed up compilation a bit. Our .java files do not need to see the .scala files.
     compileOrder := CompileOrder.JavaThenScala,
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,32 @@
+// shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
+import sbtcrossproject.{crossProject, CrossType}
+
+inThisBuild(Def.settings(
+  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.6"),
+  scalaVersion := crossScalaVersions.value.last,
+  version := "0.1.0-SNAPSHOT",
+
+  scalacOptions ++= Seq(
+    "-deprecation",
+    "-feature",
+    "-encoding",
+    "utf-8",
+    "-Xfatal-warnings",
+  )
+))
+
+lazy val reflect = crossProject(JSPlatform, JVMPlatform)
+  .in(file("."))
+  .settings(
+    scalacOptions in (Compile, doc) -= "-Xfatal-warnings",
+  )
+  .jvmSettings(
+    // Speed up compilation a bit. Our .java files do not need to see the .scala files.
+    compileOrder := CompileOrder.JavaThenScala,
+
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
+  )
+  .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
+
+lazy val reflectJVM = reflect.jvm
+lazy val reflectJS = reflect.js

--- a/js/src/main/scala/org/portablescala/reflect/Reflect.scala
+++ b/js/src/main/scala/org/portablescala/reflect/Reflect.scala
@@ -1,0 +1,81 @@
+package org.portablescala.reflect
+
+import scala.scalajs.reflect.{Reflect => SJSReflect}
+
+object Reflect {
+  /** Reflectively looks up a loadable module class.
+   *
+   *  A module class is the technical term referring to the class of a Scala
+   *  `object`. The object or one of its super types (classes or traits) must
+   *  be annotated with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the object must be "static", i.e., declared at the top-level of
+   *  a package or inside a static object.
+   *
+   *  If the module class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was not static, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   */
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
+    SJSReflect.lookupLoadableModuleClass(fqcn)
+
+  /** Reflectively looks up a loadable module class.
+   *
+   *  In Scala.js, this method ignores the parameter `loader`. Calling this
+   *  method is equivalent to
+   *  {{{
+   *  Reflect.lookupLoadableModuleClass(fqcn)
+   *  }}}
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   *
+   *  @param loader
+   *    Ignored
+   */
+  def lookupLoadableModuleClass(fqcn: String,
+      loader: ClassLoader): Option[LoadableModuleClass] = {
+    lookupLoadableModuleClass(fqcn)
+  }
+
+  /** Reflectively looks up an instantiable class.
+   *
+   *  The class or one of its super types (classes or traits) must be annotated
+   *  with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the class must not be abstract, nor be a local class (i.e., a
+   *  class defined inside a `def`). Inner classes (defined inside another
+   *  class) are supported.
+   *
+   *  If the class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was abstract or local, this
+   *  method returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   */
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
+    SJSReflect.lookupInstantiatableClass(fqcn)
+
+  /** Reflectively looks up an instantiable class.
+   *
+   *  In Scala.js, this method ignores the parameter `loader`. Calling this
+   *  method is equivalent to
+   *  {{{
+   *  Reflect.lookupInstantiatableClass(fqcn)
+   *  }}}
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   *
+   *  @param loader
+   *    Ignored
+   */
+  def lookupInstantiatableClass(fqcn: String,
+      loader: ClassLoader): Option[InstantiatableClass] = {
+    lookupInstantiatableClass(fqcn)
+  }
+}

--- a/js/src/main/scala/org/portablescala/reflect/annotation/package.scala
+++ b/js/src/main/scala/org/portablescala/reflect/annotation/package.scala
@@ -1,0 +1,6 @@
+package org.portablescala.reflect
+
+package object annotation {
+  type EnableReflectiveInstantiation =
+    scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+}

--- a/js/src/main/scala/org/portablescala/reflect/package.scala
+++ b/js/src/main/scala/org/portablescala/reflect/package.scala
@@ -1,0 +1,9 @@
+package org.portablescala
+
+package object reflect {
+  type InstantiatableClass = scala.scalajs.reflect.InstantiatableClass
+
+  type InvokableConstructor = scala.scalajs.reflect.InvokableConstructor
+
+  type LoadableModuleClass = scala.scalajs.reflect.LoadableModuleClass
+}

--- a/js/src/test/scala/org/portablescala/reflect/TestPlatform.scala
+++ b/js/src/test/scala/org/portablescala/reflect/TestPlatform.scala
@@ -1,0 +1,5 @@
+package org.portablescala.reflect
+
+object TestPlatform {
+  val isScala210OnJVM = false
+}

--- a/jvm/src/main/java/org/portablescala/reflect/annotation/EnableReflectiveInstantiation.java
+++ b/jvm/src/main/java/org/portablescala/reflect/annotation/EnableReflectiveInstantiation.java
@@ -1,0 +1,7 @@
+package org.portablescala.reflect.annotation;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EnableReflectiveInstantiation {}

--- a/jvm/src/main/scala/org/portablescala/reflect/InstantiatableClass.scala
+++ b/jvm/src/main/scala/org/portablescala/reflect/InstantiatableClass.scala
@@ -1,0 +1,45 @@
+package org.portablescala.reflect
+
+/** A wrapper for a class that can be instantiated.
+ *
+ *  @param runtimeClass
+ *    The `java.lang.Class[_]` representing the class.
+ */
+final class InstantiatableClass private[reflect] (val runtimeClass: Class[_]) {
+  /** A list of the public constructors declared in this class. */
+  val declaredConstructors: List[InvokableConstructor] =
+    runtimeClass.getConstructors().map(new InvokableConstructor(_)).toList
+
+  /** Instantiates this class using its zero-argument constructor.
+   *
+   *  @throws java.lang.InstantiationException
+   *    (caused by a `NoSuchMethodException`)
+   *    If this class does not have a public zero-argument constructor.
+   */
+  def newInstance(): Any = {
+    try {
+      runtimeClass.newInstance()
+    } catch {
+      case e: IllegalAccessException =>
+        /* The constructor exists but is private; make it look like it does not
+         * exist at all.
+         */
+        throw new InstantiationException(runtimeClass.getName).initCause(
+            new NoSuchMethodException(runtimeClass.getName + ".<init>()"))
+    }
+  }
+
+  /** Looks up a public constructor identified by the types of its formal
+   *  parameters.
+   *
+   *  If no such public constructor exists, returns `None`.
+   */
+  def getConstructor(parameterTypes: Class[_]*): Option[InvokableConstructor] = {
+    try {
+      Some(new InvokableConstructor(
+          runtimeClass.getConstructor(parameterTypes: _*)))
+    } catch {
+      case _: NoSuchMethodException => None
+    }
+  }
+}

--- a/jvm/src/main/scala/org/portablescala/reflect/InvokableConstructor.scala
+++ b/jvm/src/main/scala/org/portablescala/reflect/InvokableConstructor.scala
@@ -1,0 +1,33 @@
+package org.portablescala.reflect
+
+import java.lang.reflect.Constructor
+
+/** A description of a constructor that can reflectively invoked. */
+final class InvokableConstructor private[reflect] (ctor: Constructor[_]) {
+  /** The `Class[_]` objects representing the formal parameters of this
+   *  constructor.
+   */
+  val parameterTypes: List[Class[_]] = ctor.getParameterTypes().toList
+
+  /** Invokes this constructor to instantiate a new object.
+   *
+   *  If the underlying constructor throws an exception `e`, then `newInstance`
+   *  throws `e`, unlike `java.lang.reflect.Constructor.newInstance` which
+   *  would wrap it in a `java.lang.reflect.InvocationTargetException`.
+   *
+   *  @param args
+   *    The formal arguments to be given to the constructor.
+   */
+  def newInstance(args: Any*): Any = {
+    try {
+      ctor.newInstance(args.asInstanceOf[Seq[AnyRef]]: _*)
+    } catch {
+      case e: java.lang.reflect.InvocationTargetException =>
+        val cause = e.getCause
+        if (cause == null)
+          throw e
+        else
+          throw cause
+    }
+  }
+}

--- a/jvm/src/main/scala/org/portablescala/reflect/LoadableModuleClass.scala
+++ b/jvm/src/main/scala/org/portablescala/reflect/LoadableModuleClass.scala
@@ -1,0 +1,27 @@
+package org.portablescala.reflect
+
+/** A wrapper for a module class that can be loaded.
+ *
+ *  @param runtimeClass
+ *    The `java.lang.Class[_]` representing the module class.
+ */
+final class LoadableModuleClass private[reflect] (val runtimeClass: Class[_]) {
+  /** Loads the module instance and returns it.
+   *
+   *  If the underlying constructor throws an exception `e`, then `loadModule`
+   *  throws `e`, unlike `java.lang.reflect.Field.get` which would wrap it in a
+   *  `java.lang.reflect.ExceptionInInitializerError`.
+   */
+  def loadModule(): Any = {
+    try {
+      runtimeClass.getField("MODULE$").get(null)
+    } catch {
+      case e: java.lang.ExceptionInInitializerError =>
+        val cause = e.getCause
+        if (cause == null)
+          throw e
+        else
+          throw cause
+    }
+  }
+}

--- a/jvm/src/main/scala/org/portablescala/reflect/Reflect.scala
+++ b/jvm/src/main/scala/org/portablescala/reflect/Reflect.scala
@@ -1,0 +1,163 @@
+package org.portablescala.reflect
+
+import scala.collection.mutable
+
+import java.lang.reflect._
+
+import org.portablescala.reflect.annotation._
+
+object Reflect {
+  /** Reflectively looks up a loadable module class using `Reflect`'s own class
+   *  loader.
+   *
+   *  A module class is the technical term referring to the class of a Scala
+   *  `object`. The object or one of its super types (classes or traits) must
+   *  be annotated with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the object must be "static", i.e., declared at the top-level of
+   *  a package or inside a static object.
+   *
+   *  If the module class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was not static, this method
+   *  returns `None`.
+   *
+   *  This method is equivalent to calling
+   *  {{{
+   *  Reflect.lookupLoadableModuleClass(fqcn, Reflect.getClass.getClassLoader)
+   *  }}}
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   */
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
+    lookupLoadableModuleClass(fqcn, this.getClass.getClassLoader)
+
+  /** Reflectively looks up a loadable module class.
+   *
+   *  A module class is the technical term referring to the class of a Scala
+   *  `object`. The object or one of its super types (classes or traits) must
+   *  be annotated with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the object must be "static", i.e., declared at the top-level of
+   *  a package or inside a static object.
+   *
+   *  If the module class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was not static, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   *
+   *  @param loader
+   *    Class loader to use to load the module class
+   */
+  def lookupLoadableModuleClass(fqcn: String,
+      loader: ClassLoader): Option[LoadableModuleClass] = {
+    load(fqcn, loader).filter(isModuleClass).map(new LoadableModuleClass(_))
+  }
+
+  /** Reflectively looks up an instantiatable class using `Reflect`'s own class
+   *  loader.
+   *
+   *  The class or one of its super types (classes or traits) must be annotated
+   *  with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the class must not be abstract, nor be a local class (i.e., a
+   *  class defined inside a `def` or inside an anonymous function). Inner
+   *  classes (defined inside another class) are supported.
+   *
+   *  If the class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was abstract or local, this
+   *  method returns `None`.
+   *
+   *  This method is equivalent to calling
+   *  {{{
+   *  Reflect.lookupInstantiatableClass(fqcn, Reflect.getClass.getClassLoader)
+   *  }}}
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   */
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
+    lookupInstantiatableClass(fqcn, this.getClass.getClassLoader)
+
+  /** Reflectively looks up an instantiatable class.
+   *
+   *  The class or one of its super types (classes or traits) must be annotated
+   *  with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the class must not be abstract, nor be a local class (i.e., a
+   *  class defined inside a `def` or inside an anonymous function). Inner
+   *  classes (defined inside another class) are supported.
+   *
+   *  If the class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was abstract or local, this
+   *  method returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   *
+   *  @param loader
+   *    Class loader to use to load the class
+   */
+  def lookupInstantiatableClass(fqcn: String,
+      loader: ClassLoader): Option[InstantiatableClass] = {
+    load(fqcn, loader).filter(isInstantiatableClass).map(new InstantiatableClass(_))
+  }
+
+  private def isModuleClass(clazz: Class[_]): Boolean = {
+    try {
+      val fld = clazz.getField("MODULE$")
+      clazz.getName.endsWith("$") && (fld.getModifiers & Modifier.STATIC) != 0
+    } catch {
+      case _: NoSuchFieldException => false
+    }
+  }
+
+  private def isInstantiatableClass(clazz: Class[_]): Boolean = {
+    /* A local class will have a non-null *enclosing* class, but a null
+     * *declaring* class. For a top-level class, both are null, and for an
+     * inner class (non-local), both are the same non-null class.
+     */
+    def isLocalClass: Boolean =
+      clazz.getEnclosingClass() != clazz.getDeclaringClass()
+
+    (clazz.getModifiers() & Modifier.ABSTRACT) == 0 &&
+    clazz.getConstructors().length > 0 &&
+    !isModuleClass(clazz) &&
+    !isLocalClass
+  }
+
+  private def load(fqcn: String, loader: ClassLoader): Option[Class[_]] = {
+    try {
+      /* initialize = false, so that the constructor of a module class is not
+       * executed right away. It will only be executed when we call
+       * `loadModule`.
+       */
+      val clazz = Class.forName(fqcn, false, loader)
+      if (inheritsAnnotation(clazz)) Some(clazz)
+      else None
+    } catch {
+      case _: ClassNotFoundException => None
+    }
+  }
+
+  private def inheritsAnnotation(clazz: Class[_]): Boolean = {
+    val cache = mutable.Map.empty[Class[_], Boolean]
+
+    def c(clazz: Class[_]): Boolean =
+      cache.getOrElseUpdate(clazz, l(clazz))
+
+    def l(clazz: Class[_]): Boolean = {
+      if (clazz.getAnnotation(classOf[EnableReflectiveInstantiation]) != null) {
+        true
+      } else {
+        (Iterator(clazz.getSuperclass) ++ Iterator(clazz.getInterfaces: _*))
+          .filter(_ != null)
+          .exists(c)
+      }
+    }
+
+    c(clazz)
+  }
+}

--- a/jvm/src/test/scala/org/portablescala/reflect/TestPlatform.scala
+++ b/jvm/src/test/scala/org/portablescala/reflect/TestPlatform.scala
@@ -1,0 +1,6 @@
+package org.portablescala.reflect
+
+object TestPlatform {
+  val isScala210OnJVM =
+    scala.util.Properties.versionNumberString.startsWith("2.10.")
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).filter(_ != "").getOrElse("0.6.23")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")

--- a/shared/src/test/scala/org/portablescala/reflect/ReflectTest.scala
+++ b/shared/src/test/scala/org/portablescala/reflect/ReflectTest.scala
@@ -1,0 +1,482 @@
+package org.portablescala.reflect
+
+import scala.reflect.ClassTag
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+
+class ReflectTest {
+  import ReflectTest.{Accessors, VC, ConstructorThrowsMessage, intercept}
+
+  private final val Prefix = "org.portablescala.reflect.ReflectTest$"
+
+  private final val NameClassEnableDirect =
+    Prefix + "ClassEnableDirect"
+  private final val NameClassEnableDirectNoZeroArgCtor =
+    Prefix + "ClassEnableDirectNoZeroArgCtor"
+  private final val NameObjectEnableDirect =
+    Prefix + "ObjectEnableDirect$"
+  private final val NameTraitEnableDirect =
+    Prefix + "TraitEnableDirect"
+  private final val NameAbstractClassEnableDirect =
+    Prefix + "AbstractClassEnableDirect"
+  private final val NameClassNoPublicConstructorEnableDirect =
+    Prefix + "ClassNoPublicConstructorEnableDirect"
+
+  private final val NameInnerClass = {
+    Prefix + "ClassWithInnerClassWithEnableReflectiveInstantiation$" +
+    "InnerClassWithEnableReflectiveInstantiation"
+  }
+
+  private final val NameClassEnableIndirect =
+    Prefix + "ClassEnableIndirect"
+  private final val NameClassEnableIndirectNoZeroArgCtor =
+    Prefix + "ClassEnableIndirectNoZeroArgCtor"
+  private final val NameObjectEnableIndirect =
+    Prefix + "ObjectEnableIndirect$"
+  private final val NameTraitEnableIndirect =
+    Prefix + "TraitEnableIndirect"
+  private final val NameAbstractClassEnableIndirect =
+    Prefix + "AbstractClassEnableIndirect"
+  private final val NameClassNoPublicConstructorEnableIndirect =
+    Prefix + "ClassNoPublicConstructorEnableIndirect"
+
+  private final val NameClassDisable =
+    Prefix + "ClassDisable"
+  private final val NameObjectDisable =
+    Prefix + "ObjectDisable$"
+  private final val NameTraitDisable =
+    Prefix + "TraitDisable"
+
+  private final val NameInnerObject = {
+    Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
+    "InnerObjectWithEnableReflectiveInstantiation"
+  }
+
+  private final val NameObjectWithInitialization =
+    Prefix + "ObjectWithInitialization$"
+  private final val NameObjectWithThrowingCtor =
+    Prefix + "ObjectWithThrowingCtor$"
+  private final val NameClassWithThrowingCtor =
+    Prefix + "ClassWithThrowingCtor"
+
+  @Test def testClassRuntimeClass(): Unit = {
+    def test(name: String): Unit = {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      val runtimeClass = optClassData.get.runtimeClass
+      assertEquals(name, name, runtimeClass.getName)
+    }
+
+    test(NameClassEnableDirect)
+    test(NameClassEnableDirectNoZeroArgCtor)
+    test(NameClassEnableIndirect)
+    test(NameClassEnableIndirectNoZeroArgCtor)
+  }
+
+  @Test def testObjectRuntimeClass(): Unit = {
+    def test(name: String): Unit = {
+      val optClassData = Reflect.lookupLoadableModuleClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      val runtimeClass = optClassData.get.runtimeClass
+      assertEquals(name, name, runtimeClass.getName)
+    }
+
+    test(NameObjectEnableDirect)
+    test(NameObjectEnableIndirect)
+  }
+
+  @Test def testClassCannotBeFound(): Unit = {
+    def test(name: String): Unit =
+      assertTrue(name, Reflect.lookupInstantiatableClass(name).isEmpty)
+
+    test(NameObjectEnableDirect)
+    test(NameTraitEnableDirect)
+    test(NameAbstractClassEnableDirect)
+    test(NameClassNoPublicConstructorEnableDirect)
+    test(NameObjectEnableIndirect)
+    test(NameTraitEnableIndirect)
+    test(NameAbstractClassEnableIndirect)
+    test(NameClassNoPublicConstructorEnableIndirect)
+    test(NameClassDisable)
+    test(NameObjectDisable)
+    test(NameTraitDisable)
+  }
+
+  @Test def testObjectCannotBeFound(): Unit = {
+    def test(name: String): Unit =
+      assertTrue(name, Reflect.lookupLoadableModuleClass(name).isEmpty)
+
+    test(NameClassEnableDirect)
+    test(NameClassEnableDirectNoZeroArgCtor)
+    test(NameTraitEnableDirect)
+    test(NameAbstractClassEnableDirect)
+    test(NameClassNoPublicConstructorEnableDirect)
+    test(NameClassEnableIndirect)
+    test(NameTraitEnableIndirect)
+    test(NameAbstractClassEnableIndirect)
+    test(NameClassNoPublicConstructorEnableIndirect)
+    test(NameClassDisable)
+    test(NameObjectDisable)
+    test(NameTraitDisable)
+  }
+
+  @Test def testClassNoArgCtor(): Unit = {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableIndirect)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      val instance = classData.newInstance().asInstanceOf[Accessors]
+      assertEquals(name, -1, instance.x)
+      assertEquals(name, name.stripPrefix(Prefix), instance.y)
+    }
+  }
+
+  @Test def testClassNoArgCtorErrorCase(): Unit = {
+    for (name <- Seq(NameClassEnableDirectNoZeroArgCtor,
+        NameClassEnableIndirectNoZeroArgCtor)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      intercept[InstantiationException](classData.newInstance())
+    }
+  }
+
+  @Test def testClassCtorWithArgs(): Unit = {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+        NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val optCtorIntString =
+        classData.getConstructor(classOf[Int], classOf[String])
+      assertTrue(optCtorIntString.isDefined)
+      val instanceIntString =
+        optCtorIntString.get.newInstance(543, "foobar").asInstanceOf[Accessors]
+      assertEquals(543, instanceIntString.x)
+      assertEquals("foobar", instanceIntString.y)
+
+      val optCtorInt = classData.getConstructor(classOf[Int])
+      assertTrue(optCtorInt.isDefined)
+      val instanceInt =
+        optCtorInt.get.newInstance(123).asInstanceOf[Accessors]
+      assertEquals(123, instanceInt.x)
+      assertEquals(name.stripPrefix(Prefix), instanceInt.y)
+
+      // Value class is seen as its underlying
+      val optCtorShort = classData.getConstructor(classOf[Short])
+      assertTrue(optCtorShort.isDefined)
+      val instanceShort =
+        optCtorShort.get.newInstance(21.toShort).asInstanceOf[Accessors]
+      assertEquals(42, instanceShort.x)
+      assertEquals(name.stripPrefix(Prefix), instanceShort.y)
+
+      // Non-existent
+      assertFalse(classData.getConstructor(classOf[Boolean]).isDefined)
+      assertFalse(classData.getConstructor(classOf[VC]).isDefined)
+
+      // Non-public
+      assertFalse(classData.getConstructor(classOf[String]).isDefined)
+      assertFalse(classData.getConstructor(classOf[Double]).isDefined)
+    }
+  }
+
+  @Test def testInnerClass(): Unit = {
+    val outer = new ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation(15)
+
+    val optClassData = Reflect.lookupInstantiatableClass(NameInnerClass)
+    assertTrue(optClassData.isDefined)
+    val classData = optClassData.get
+
+    val optCtorOuterString =
+      classData.getConstructor(outer.getClass, classOf[String])
+    assertTrue(optCtorOuterString.isDefined)
+    val instanceOuterString =
+      optCtorOuterString.get.newInstance(outer, "babar").asInstanceOf[Accessors]
+    assertEquals(15, instanceOuterString.x)
+    assertEquals("babar", instanceOuterString.y)
+  }
+
+  private val classInsideLambdaInsideCtor: () => Class[_] = { () =>
+    @EnableReflectiveInstantiation
+    class LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideCtor
+
+    classOf[LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideCtor]
+  }
+
+  @Test def testLocalClass(): Unit = {
+    assumeFalse("Scala.js 1.0.0-M3 does not disable local classes",
+        1.0.toString() == "1" &&
+        System.getProperty("java.vm.version") == "1.0.0-M3")
+
+    def assertCannotFind(c: Class[_]): Unit = {
+      val fqcn = c.getName
+      assertFalse(fqcn, Reflect.lookupInstantiatableClass(fqcn).isDefined)
+    }
+
+    // Inside a method
+    @EnableReflectiveInstantiation
+    class LocalClassWithEnableReflectiveInstantiationInsideMethod
+
+    assertCannotFind(
+        classOf[LocalClassWithEnableReflectiveInstantiationInsideMethod])
+
+    assumeFalse(
+        "Scala/JVM 2.10.x does not correctly configure classes in lambdas as local",
+        TestPlatform.isScala210OnJVM)
+
+    // In a lambda whose owner is ultimately the constructor of the class
+    assertCannotFind(classInsideLambdaInsideCtor())
+
+    // Inside lambda whose owner is a method
+    val f = { () =>
+      @EnableReflectiveInstantiation
+      class LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod
+
+      assertCannotFind(
+          classOf[LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod])
+    }
+    f()
+  }
+
+  @Test def testObjectLoad(): Unit = {
+    for (name <- Seq(NameObjectEnableDirect, NameObjectEnableIndirect)) {
+      val optClassData = Reflect.lookupLoadableModuleClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      val instance = classData.loadModule().asInstanceOf[Accessors]
+      assertEquals(name, 101, instance.x)
+      assertEquals(name, name.stripPrefix(Prefix), instance.y)
+    }
+  }
+
+  @Test def testObjectLoadInitialization(): Unit = {
+    assertFalse(ReflectTest.ObjectWithInitializationHasBeenInitialized)
+    val optClassData =
+      Reflect.lookupLoadableModuleClass(NameObjectWithInitialization)
+    assertTrue(optClassData.isDefined)
+    val classData = optClassData.get
+    assertFalse(ReflectTest.ObjectWithInitializationHasBeenInitialized)
+
+    classData.loadModule()
+    assertTrue(ReflectTest.ObjectWithInitializationHasBeenInitialized)
+  }
+
+  @Test def testExceptionsInConstructor(): Unit = {
+    val objClassData =
+      Reflect.lookupLoadableModuleClass(NameObjectWithThrowingCtor).get
+    val e1 = intercept[ArithmeticException] {
+      objClassData.loadModule()
+    }
+    assertEquals(ConstructorThrowsMessage, e1.getMessage)
+
+    val clsClassData =
+      Reflect.lookupInstantiatableClass(NameClassWithThrowingCtor).get
+    val e2 = intercept[ArithmeticException] {
+      clsClassData.newInstance()
+    }
+    assertEquals(ConstructorThrowsMessage, e2.getMessage)
+
+    val ctor = clsClassData.getConstructor().get
+    val e3 = intercept[ArithmeticException] {
+      ctor.newInstance()
+    }
+    assertEquals(ConstructorThrowsMessage, e3.getMessage)
+  }
+
+  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228(): Unit = {
+    assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
+    assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
+  }
+
+  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227(): Unit = {
+    // Test that the presence of the following code does not prevent linking
+    { () =>
+      @EnableReflectiveInstantiation
+      class Foo
+    }
+  }
+}
+
+object ReflectTest {
+  private final val ConstructorThrowsMessage = "constructor throws"
+
+  def intercept[T <: Throwable : ClassTag](body: => Unit): T = {
+    try {
+      body
+      throw new AssertionError("no exception was thrown")
+    } catch {
+      case t: T => t
+    }
+  }
+
+  trait Accessors {
+    val x: Int
+    val y: String
+  }
+
+  final class VC(val self: Short) extends AnyVal
+
+  /* FIXME In the classes below, protected constructors are commented out,
+   * because Scala.js and Scala/JVM do not agree on whether they should be
+   * visible. Scala.js says no, but Scala/JVM compiles them as public, and
+   * therefore says yes.
+   */
+
+  // Entities with directly enabled reflection
+
+  @EnableReflectiveInstantiation
+  class ClassEnableDirect(val x: Int, val y: String) extends Accessors {
+    def this(x: Int) = this(x, "ClassEnableDirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassEnableDirectNoZeroArgCtor(val x: Int, val y: String)
+      extends Accessors {
+    def this(x: Int) = this(x, "ClassEnableDirectNoZeroArgCtor")
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  object ObjectEnableDirect extends Accessors {
+    val x = 101
+    val y = "ObjectEnableDirect$"
+  }
+
+  @EnableReflectiveInstantiation
+  trait TraitEnableDirect extends Accessors
+
+  @EnableReflectiveInstantiation
+  abstract class AbstractClassEnableDirect(val x: Int, val y: String)
+      extends Accessors {
+
+    def this(x: Int) = this(x, "AbstractClassEnableDirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassNoPublicConstructorEnableDirect private (val x: Int, val y: String)
+      extends Accessors {
+
+    //protected def this(y: String) = this(-5, y)
+  }
+
+  class ClassWithInnerClassWithEnableReflectiveInstantiation(_x: Int) {
+    @EnableReflectiveInstantiation
+    class InnerClassWithEnableReflectiveInstantiation(_y: String)
+        extends Accessors {
+      val x = _x
+      val y = _y
+    }
+  }
+
+  // Entities with reflection enabled by inheritance
+
+  @EnableReflectiveInstantiation
+  trait EnablingTrait
+
+  class ClassEnableIndirect(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    def this(x: Int) = this(x, "ClassEnableIndirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  class ClassEnableIndirectNoZeroArgCtor(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+    def this(x: Int) = this(x, "ClassEnableIndirectNoZeroArgCtor")
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  object ObjectEnableIndirect extends EnablingTrait with Accessors {
+    val x = 101
+    val y = "ObjectEnableIndirect$"
+  }
+
+  trait TraitEnableIndirect extends EnablingTrait with Accessors
+
+  abstract class AbstractClassEnableIndirect(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    def this(x: Int) = this(x, "AbstractClassEnableIndirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  class ClassNoPublicConstructorEnableIndirect private (
+      val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    //protected def this(y: String) = this(-5, y)
+  }
+
+  // Entities with reflection disabled
+
+  class ClassDisable(val x: Int, val y: String) extends Accessors
+
+  object ObjectDisable extends Accessors {
+    val x = 101
+    val y = "ObjectDisable$"
+  }
+
+  trait TraitDisable extends Accessors
+
+  // Corner cases
+
+  var ObjectWithInitializationHasBeenInitialized: Boolean = false
+
+  @EnableReflectiveInstantiation
+  object ObjectWithInitialization {
+    ObjectWithInitializationHasBeenInitialized = true
+  }
+
+  @EnableReflectiveInstantiation
+  object ObjectWithThrowingCtor {
+    throw new ArithmeticException(ConstructorThrowsMessage)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassWithThrowingCtor {
+    throw new ArithmeticException(ConstructorThrowsMessage)
+  }
+
+  // Regression cases
+
+  class ClassWithInnerObjectWithEnableReflectiveInstantiation {
+    @EnableReflectiveInstantiation
+    object InnerObjectWithEnableReflectiveInstantiation
+  }
+}

--- a/shared/src/test/scala/org/portablescala/reflect/ReflectTest.scala
+++ b/shared/src/test/scala/org/portablescala/reflect/ReflectTest.scala
@@ -8,6 +8,13 @@ import org.junit.Test
 
 import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
 
+package subpackage {
+  @EnableReflectiveInstantiation
+  private class PrivateClassEnableDirect {
+    override def toString(): String = "instance of PrivateClassEnableDirect"
+  }
+}
+
 class ReflectTest {
   import ReflectTest.{Accessors, VC, ConstructorThrowsMessage, intercept}
 
@@ -62,6 +69,9 @@ class ReflectTest {
     Prefix + "ObjectWithThrowingCtor$"
   private final val NameClassWithThrowingCtor =
     Prefix + "ClassWithThrowingCtor"
+
+  private final val NamePrivateClassEnableDirect =
+    "org.portablescala.reflect.subpackage.PrivateClassEnableDirect"
 
   @Test def testClassRuntimeClass(): Unit = {
     def test(name: String): Unit = {
@@ -293,6 +303,17 @@ class ReflectTest {
       ctor.newInstance()
     }
     assertEquals(ConstructorThrowsMessage, e3.getMessage)
+  }
+
+  @Test def testPrivateClass(): Unit = {
+    // Private classes are discoverable
+
+    val optClassData = Reflect.lookupInstantiatableClass(NamePrivateClassEnableDirect)
+    assertTrue("1", optClassData.isDefined)
+    val classData = optClassData.get
+
+    val obj = classData.newInstance()
+    assertEquals("2", "instance of PrivateClassEnableDirect", obj.toString())
   }
 
   @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228(): Unit = {


### PR DESCRIPTION
The Scala Native version is not there yet, as Scala Native does not have yet the necessary mechanisms to implement the API.

The only discrepancy between JVM and JS is the behavior of `protected` constructors. The JVM version considers that they are visible, because they are compiled to `public` in the bytecode, while Scala.js explicitly excludes them. It seems that the most reasonable fix would be to allow access to protected constructors in Scala.js' core `Reflect` mechanism.