### PR TITLE
WIP: Add experimental support for ScalaNative

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ inThisBuild(Def.settings(
     Some("scm:git:git@github.com:portable-scala/portable-scala-reflect.git"))),
 ))
 
-lazy val `portable-scala-reflect` = crossProject(JSPlatform, JVMPlatform)
+lazy val `portable-scala-reflect` =
+    crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("."))
   .settings(
     scalacOptions in (Compile, doc) -= "-Xfatal-warnings",
@@ -78,4 +79,11 @@ lazy val `portable-scala-reflect` = crossProject(JSPlatform, JVMPlatform)
       if (scalaJSVersion.startsWith("0.6.")) prev
       else prev.filter(v => !v.startsWith("2.10."))
     }
+  )
+  .nativeSettings(
+    crossScalaVersions := Seq("2.11.12"),
+    scalaVersion := "2.11.12",
+    libraryDependencies ++= Seq(
+      "org.scala-native" %%% "test-interface" % nativeVersion
+    )
   )

--- a/js/src/test/scala/org/portablescala/reflect/ReflectTest.scala
+++ b/js/src/test/scala/org/portablescala/reflect/ReflectTest.scala
@@ -35,7 +35,7 @@ class ReflectTest {
 
   private final val NameInnerClass = {
     Prefix + "ClassWithInnerClassWithEnableReflectiveInstantiation$" +
-    "InnerClassWithEnableReflectiveInstantiation"
+      "InnerClassWithEnableReflectiveInstantiation"
   }
 
   private final val NameClassEnableIndirect =
@@ -60,7 +60,7 @@ class ReflectTest {
 
   private final val NameInnerObject = {
     Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
-    "InnerObjectWithEnableReflectiveInstantiation"
+      "InnerObjectWithEnableReflectiveInstantiation"
   }
 
   private final val NameObjectWithInitialization =
@@ -152,7 +152,7 @@ class ReflectTest {
 
   @Test def testClassNoArgCtorErrorCase(): Unit = {
     for (name <- Seq(NameClassEnableDirectNoZeroArgCtor,
-        NameClassEnableIndirectNoZeroArgCtor)) {
+                     NameClassEnableIndirectNoZeroArgCtor)) {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(name, optClassData.isDefined)
       val classData = optClassData.get
@@ -162,8 +162,10 @@ class ReflectTest {
   }
 
   @Test def testClassCtorWithArgs(): Unit = {
-    for (name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
-        NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)) {
+    for (name <- Seq(NameClassEnableDirect,
+                     NameClassEnableDirectNoZeroArgCtor,
+                     NameClassEnableIndirect,
+                     NameClassEnableIndirectNoZeroArgCtor)) {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(optClassData.isDefined)
       val classData = optClassData.get
@@ -202,7 +204,8 @@ class ReflectTest {
   }
 
   @Test def testInnerClass(): Unit = {
-    val outer = new ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation(15)
+    val outer =
+      new ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation(15)
 
     val optClassData = Reflect.lookupInstantiatableClass(NameInnerClass)
     assertTrue(optClassData.isDefined)
@@ -235,11 +238,11 @@ class ReflectTest {
     class LocalClassWithEnableReflectiveInstantiationInsideMethod
 
     assertCannotFind(
-        classOf[LocalClassWithEnableReflectiveInstantiationInsideMethod])
+      classOf[LocalClassWithEnableReflectiveInstantiationInsideMethod])
 
     assumeFalse(
-        "Scala/JVM 2.10.x does not correctly configure classes in lambdas as local",
-        TestPlatform.isScala210OnJVM)
+      "Scala/JVM 2.10.x does not correctly configure classes in lambdas as local",
+      TestPlatform.isScala210OnJVM)
 
     // In a lambda whose owner is ultimately the constructor of the class
     assertCannotFind(classInsideLambdaInsideCtor())
@@ -250,7 +253,8 @@ class ReflectTest {
       class LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod
 
       assertCannotFind(
-          classOf[LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod])
+        classOf[
+          LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod])
     }
     f()
   }
@@ -304,7 +308,8 @@ class ReflectTest {
   @Test def testPrivateClass(): Unit = {
     // Private classes are discoverable
 
-    val optClassData = Reflect.lookupInstantiatableClass(NamePrivateClassEnableDirect)
+    val optClassData =
+      Reflect.lookupInstantiatableClass(NamePrivateClassEnableDirect)
     assertTrue("1", optClassData.isDefined)
     val classData = optClassData.get
 
@@ -312,12 +317,14 @@ class ReflectTest {
     assertEquals("2", "instance of PrivateClassEnableDirect", obj.toString())
   }
 
-  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228(): Unit = {
+  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228()
+    : Unit = {
     assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
     assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
   }
 
-  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227(): Unit = {
+  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227()
+    : Unit = {
     // Test that the presence of the following code does not prevent linking
     val f = { () =>
       @EnableReflectiveInstantiation
@@ -330,7 +337,7 @@ class ReflectTest {
 object ReflectTest {
   private final val ConstructorThrowsMessage = "constructor throws"
 
-  def intercept[T <: Throwable : ClassTag](body: => Unit): T = {
+  def intercept[T <: Throwable: ClassTag](body: => Unit): T = {
     try {
       body
       throw new AssertionError("no exception was thrown")
@@ -417,7 +424,8 @@ object ReflectTest {
   trait EnablingTrait
 
   class ClassEnableIndirect(val x: Int, val y: String)
-      extends EnablingTrait with Accessors {
+      extends EnablingTrait
+      with Accessors {
 
     def this(x: Int) = this(x, "ClassEnableIndirect")
     def this() = this(-1)
@@ -428,7 +436,8 @@ object ReflectTest {
   }
 
   class ClassEnableIndirectNoZeroArgCtor(val x: Int, val y: String)
-      extends EnablingTrait with Accessors {
+      extends EnablingTrait
+      with Accessors {
     def this(x: Int) = this(x, "ClassEnableIndirectNoZeroArgCtor")
     def this(vc: VC) = this(vc.self.toInt * 2)
 
@@ -444,7 +453,8 @@ object ReflectTest {
   trait TraitEnableIndirect extends EnablingTrait with Accessors
 
   abstract class AbstractClassEnableIndirect(val x: Int, val y: String)
-      extends EnablingTrait with Accessors {
+      extends EnablingTrait
+      with Accessors {
 
     def this(x: Int) = this(x, "AbstractClassEnableIndirect")
     def this() = this(-1)
@@ -454,9 +464,10 @@ object ReflectTest {
     private def this(d: Double) = this(d.toInt)
   }
 
-  class ClassNoPublicConstructorEnableIndirect private (
-      val x: Int, val y: String)
-      extends EnablingTrait with Accessors {
+  class ClassNoPublicConstructorEnableIndirect private (val x: Int,
+                                                        val y: String)
+      extends EnablingTrait
+      with Accessors {
 
     //protected def this(y: String) = this(-5, y)
   }

--- a/js/src/test/scala/org/portablescala/reflect/ReflectTest.scala
+++ b/js/src/test/scala/org/portablescala/reflect/ReflectTest.scala
@@ -35,7 +35,7 @@ class ReflectTest {
 
   private final val NameInnerClass = {
     Prefix + "ClassWithInnerClassWithEnableReflectiveInstantiation$" +
-      "InnerClassWithEnableReflectiveInstantiation"
+    "InnerClassWithEnableReflectiveInstantiation"
   }
 
   private final val NameClassEnableIndirect =
@@ -60,7 +60,7 @@ class ReflectTest {
 
   private final val NameInnerObject = {
     Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
-      "InnerObjectWithEnableReflectiveInstantiation"
+    "InnerObjectWithEnableReflectiveInstantiation"
   }
 
   private final val NameObjectWithInitialization =
@@ -152,7 +152,7 @@ class ReflectTest {
 
   @Test def testClassNoArgCtorErrorCase(): Unit = {
     for (name <- Seq(NameClassEnableDirectNoZeroArgCtor,
-                     NameClassEnableIndirectNoZeroArgCtor)) {
+        NameClassEnableIndirectNoZeroArgCtor)) {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(name, optClassData.isDefined)
       val classData = optClassData.get
@@ -162,10 +162,8 @@ class ReflectTest {
   }
 
   @Test def testClassCtorWithArgs(): Unit = {
-    for (name <- Seq(NameClassEnableDirect,
-                     NameClassEnableDirectNoZeroArgCtor,
-                     NameClassEnableIndirect,
-                     NameClassEnableIndirectNoZeroArgCtor)) {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+        NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)) {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(optClassData.isDefined)
       val classData = optClassData.get
@@ -204,8 +202,7 @@ class ReflectTest {
   }
 
   @Test def testInnerClass(): Unit = {
-    val outer =
-      new ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation(15)
+    val outer = new ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation(15)
 
     val optClassData = Reflect.lookupInstantiatableClass(NameInnerClass)
     assertTrue(optClassData.isDefined)
@@ -238,11 +235,11 @@ class ReflectTest {
     class LocalClassWithEnableReflectiveInstantiationInsideMethod
 
     assertCannotFind(
-      classOf[LocalClassWithEnableReflectiveInstantiationInsideMethod])
+        classOf[LocalClassWithEnableReflectiveInstantiationInsideMethod])
 
     assumeFalse(
-      "Scala/JVM 2.10.x does not correctly configure classes in lambdas as local",
-      TestPlatform.isScala210OnJVM)
+        "Scala/JVM 2.10.x does not correctly configure classes in lambdas as local",
+        TestPlatform.isScala210OnJVM)
 
     // In a lambda whose owner is ultimately the constructor of the class
     assertCannotFind(classInsideLambdaInsideCtor())
@@ -253,8 +250,7 @@ class ReflectTest {
       class LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod
 
       assertCannotFind(
-        classOf[
-          LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod])
+          classOf[LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod])
     }
     f()
   }
@@ -308,8 +304,7 @@ class ReflectTest {
   @Test def testPrivateClass(): Unit = {
     // Private classes are discoverable
 
-    val optClassData =
-      Reflect.lookupInstantiatableClass(NamePrivateClassEnableDirect)
+    val optClassData = Reflect.lookupInstantiatableClass(NamePrivateClassEnableDirect)
     assertTrue("1", optClassData.isDefined)
     val classData = optClassData.get
 
@@ -317,14 +312,12 @@ class ReflectTest {
     assertEquals("2", "instance of PrivateClassEnableDirect", obj.toString())
   }
 
-  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228()
-    : Unit = {
+  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228(): Unit = {
     assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
     assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
   }
 
-  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227()
-    : Unit = {
+  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227(): Unit = {
     // Test that the presence of the following code does not prevent linking
     val f = { () =>
       @EnableReflectiveInstantiation
@@ -337,7 +330,7 @@ class ReflectTest {
 object ReflectTest {
   private final val ConstructorThrowsMessage = "constructor throws"
 
-  def intercept[T <: Throwable: ClassTag](body: => Unit): T = {
+  def intercept[T <: Throwable : ClassTag](body: => Unit): T = {
     try {
       body
       throw new AssertionError("no exception was thrown")
@@ -424,8 +417,7 @@ object ReflectTest {
   trait EnablingTrait
 
   class ClassEnableIndirect(val x: Int, val y: String)
-      extends EnablingTrait
-      with Accessors {
+      extends EnablingTrait with Accessors {
 
     def this(x: Int) = this(x, "ClassEnableIndirect")
     def this() = this(-1)
@@ -436,8 +428,7 @@ object ReflectTest {
   }
 
   class ClassEnableIndirectNoZeroArgCtor(val x: Int, val y: String)
-      extends EnablingTrait
-      with Accessors {
+      extends EnablingTrait with Accessors {
     def this(x: Int) = this(x, "ClassEnableIndirectNoZeroArgCtor")
     def this(vc: VC) = this(vc.self.toInt * 2)
 
@@ -453,8 +444,7 @@ object ReflectTest {
   trait TraitEnableIndirect extends EnablingTrait with Accessors
 
   abstract class AbstractClassEnableIndirect(val x: Int, val y: String)
-      extends EnablingTrait
-      with Accessors {
+      extends EnablingTrait with Accessors {
 
     def this(x: Int) = this(x, "AbstractClassEnableIndirect")
     def this() = this(-1)
@@ -464,10 +454,9 @@ object ReflectTest {
     private def this(d: Double) = this(d.toInt)
   }
 
-  class ClassNoPublicConstructorEnableIndirect private (val x: Int,
-                                                        val y: String)
-      extends EnablingTrait
-      with Accessors {
+  class ClassNoPublicConstructorEnableIndirect private (
+      val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
 
     //protected def this(y: String) = this(-5, y)
   }

--- a/jvm/src/test/scala/org/portablescala/reflect/ReflectTest.scala
+++ b/jvm/src/test/scala/org/portablescala/reflect/ReflectTest.scala
@@ -35,7 +35,7 @@ class ReflectTest {
 
   private final val NameInnerClass = {
     Prefix + "ClassWithInnerClassWithEnableReflectiveInstantiation$" +
-      "InnerClassWithEnableReflectiveInstantiation"
+    "InnerClassWithEnableReflectiveInstantiation"
   }
 
   private final val NameClassEnableIndirect =
@@ -60,7 +60,7 @@ class ReflectTest {
 
   private final val NameInnerObject = {
     Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
-      "InnerObjectWithEnableReflectiveInstantiation"
+    "InnerObjectWithEnableReflectiveInstantiation"
   }
 
   private final val NameObjectWithInitialization =
@@ -152,7 +152,7 @@ class ReflectTest {
 
   @Test def testClassNoArgCtorErrorCase(): Unit = {
     for (name <- Seq(NameClassEnableDirectNoZeroArgCtor,
-                     NameClassEnableIndirectNoZeroArgCtor)) {
+        NameClassEnableIndirectNoZeroArgCtor)) {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(name, optClassData.isDefined)
       val classData = optClassData.get
@@ -162,10 +162,8 @@ class ReflectTest {
   }
 
   @Test def testClassCtorWithArgs(): Unit = {
-    for (name <- Seq(NameClassEnableDirect,
-                     NameClassEnableDirectNoZeroArgCtor,
-                     NameClassEnableIndirect,
-                     NameClassEnableIndirectNoZeroArgCtor)) {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+        NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)) {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(optClassData.isDefined)
       val classData = optClassData.get
@@ -204,8 +202,7 @@ class ReflectTest {
   }
 
   @Test def testInnerClass(): Unit = {
-    val outer =
-      new ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation(15)
+    val outer = new ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation(15)
 
     val optClassData = Reflect.lookupInstantiatableClass(NameInnerClass)
     assertTrue(optClassData.isDefined)
@@ -238,11 +235,11 @@ class ReflectTest {
     class LocalClassWithEnableReflectiveInstantiationInsideMethod
 
     assertCannotFind(
-      classOf[LocalClassWithEnableReflectiveInstantiationInsideMethod])
+        classOf[LocalClassWithEnableReflectiveInstantiationInsideMethod])
 
     assumeFalse(
-      "Scala/JVM 2.10.x does not correctly configure classes in lambdas as local",
-      TestPlatform.isScala210OnJVM)
+        "Scala/JVM 2.10.x does not correctly configure classes in lambdas as local",
+        TestPlatform.isScala210OnJVM)
 
     // In a lambda whose owner is ultimately the constructor of the class
     assertCannotFind(classInsideLambdaInsideCtor())
@@ -253,8 +250,7 @@ class ReflectTest {
       class LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod
 
       assertCannotFind(
-        classOf[
-          LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod])
+          classOf[LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod])
     }
     f()
   }
@@ -308,8 +304,7 @@ class ReflectTest {
   @Test def testPrivateClass(): Unit = {
     // Private classes are discoverable
 
-    val optClassData =
-      Reflect.lookupInstantiatableClass(NamePrivateClassEnableDirect)
+    val optClassData = Reflect.lookupInstantiatableClass(NamePrivateClassEnableDirect)
     assertTrue("1", optClassData.isDefined)
     val classData = optClassData.get
 
@@ -317,14 +312,12 @@ class ReflectTest {
     assertEquals("2", "instance of PrivateClassEnableDirect", obj.toString())
   }
 
-  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228()
-    : Unit = {
+  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228(): Unit = {
     assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
     assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
   }
 
-  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227()
-    : Unit = {
+  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227(): Unit = {
     // Test that the presence of the following code does not prevent linking
     val f = { () =>
       @EnableReflectiveInstantiation
@@ -337,7 +330,7 @@ class ReflectTest {
 object ReflectTest {
   private final val ConstructorThrowsMessage = "constructor throws"
 
-  def intercept[T <: Throwable: ClassTag](body: => Unit): T = {
+  def intercept[T <: Throwable : ClassTag](body: => Unit): T = {
     try {
       body
       throw new AssertionError("no exception was thrown")
@@ -424,8 +417,7 @@ object ReflectTest {
   trait EnablingTrait
 
   class ClassEnableIndirect(val x: Int, val y: String)
-      extends EnablingTrait
-      with Accessors {
+      extends EnablingTrait with Accessors {
 
     def this(x: Int) = this(x, "ClassEnableIndirect")
     def this() = this(-1)
@@ -436,8 +428,7 @@ object ReflectTest {
   }
 
   class ClassEnableIndirectNoZeroArgCtor(val x: Int, val y: String)
-      extends EnablingTrait
-      with Accessors {
+      extends EnablingTrait with Accessors {
     def this(x: Int) = this(x, "ClassEnableIndirectNoZeroArgCtor")
     def this(vc: VC) = this(vc.self.toInt * 2)
 
@@ -453,8 +444,7 @@ object ReflectTest {
   trait TraitEnableIndirect extends EnablingTrait with Accessors
 
   abstract class AbstractClassEnableIndirect(val x: Int, val y: String)
-      extends EnablingTrait
-      with Accessors {
+      extends EnablingTrait with Accessors {
 
     def this(x: Int) = this(x, "AbstractClassEnableIndirect")
     def this() = this(-1)
@@ -464,10 +454,9 @@ object ReflectTest {
     private def this(d: Double) = this(d.toInt)
   }
 
-  class ClassNoPublicConstructorEnableIndirect private (val x: Int,
-                                                        val y: String)
-      extends EnablingTrait
-      with Accessors {
+  class ClassNoPublicConstructorEnableIndirect private (
+      val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
 
     //protected def this(y: String) = this(-5, y)
   }

--- a/jvm/src/test/scala/org/portablescala/reflect/ReflectTest.scala
+++ b/jvm/src/test/scala/org/portablescala/reflect/ReflectTest.scala
@@ -1,0 +1,511 @@
+package org.portablescala.reflect
+
+import scala.reflect.ClassTag
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+
+package subpackage {
+  @EnableReflectiveInstantiation
+  private class PrivateClassEnableDirect {
+    override def toString(): String = "instance of PrivateClassEnableDirect"
+  }
+}
+
+class ReflectTest {
+  import ReflectTest.{Accessors, VC, ConstructorThrowsMessage, intercept}
+
+  private final val Prefix = "org.portablescala.reflect.ReflectTest$"
+
+  private final val NameClassEnableDirect =
+    Prefix + "ClassEnableDirect"
+  private final val NameClassEnableDirectNoZeroArgCtor =
+    Prefix + "ClassEnableDirectNoZeroArgCtor"
+  private final val NameObjectEnableDirect =
+    Prefix + "ObjectEnableDirect$"
+  private final val NameTraitEnableDirect =
+    Prefix + "TraitEnableDirect"
+  private final val NameAbstractClassEnableDirect =
+    Prefix + "AbstractClassEnableDirect"
+  private final val NameClassNoPublicConstructorEnableDirect =
+    Prefix + "ClassNoPublicConstructorEnableDirect"
+
+  private final val NameInnerClass = {
+    Prefix + "ClassWithInnerClassWithEnableReflectiveInstantiation$" +
+      "InnerClassWithEnableReflectiveInstantiation"
+  }
+
+  private final val NameClassEnableIndirect =
+    Prefix + "ClassEnableIndirect"
+  private final val NameClassEnableIndirectNoZeroArgCtor =
+    Prefix + "ClassEnableIndirectNoZeroArgCtor"
+  private final val NameObjectEnableIndirect =
+    Prefix + "ObjectEnableIndirect$"
+  private final val NameTraitEnableIndirect =
+    Prefix + "TraitEnableIndirect"
+  private final val NameAbstractClassEnableIndirect =
+    Prefix + "AbstractClassEnableIndirect"
+  private final val NameClassNoPublicConstructorEnableIndirect =
+    Prefix + "ClassNoPublicConstructorEnableIndirect"
+
+  private final val NameClassDisable =
+    Prefix + "ClassDisable"
+  private final val NameObjectDisable =
+    Prefix + "ObjectDisable$"
+  private final val NameTraitDisable =
+    Prefix + "TraitDisable"
+
+  private final val NameInnerObject = {
+    Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
+      "InnerObjectWithEnableReflectiveInstantiation"
+  }
+
+  private final val NameObjectWithInitialization =
+    Prefix + "ObjectWithInitialization$"
+  private final val NameObjectWithThrowingCtor =
+    Prefix + "ObjectWithThrowingCtor$"
+  private final val NameClassWithThrowingCtor =
+    Prefix + "ClassWithThrowingCtor"
+
+  private final val NamePrivateClassEnableDirect =
+    "org.portablescala.reflect.subpackage.PrivateClassEnableDirect"
+
+  @Test def testClassRuntimeClass(): Unit = {
+    def test(name: String): Unit = {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      val runtimeClass = optClassData.get.runtimeClass
+      assertEquals(name, name, runtimeClass.getName)
+    }
+
+    test(NameClassEnableDirect)
+    test(NameClassEnableDirectNoZeroArgCtor)
+    test(NameClassEnableIndirect)
+    test(NameClassEnableIndirectNoZeroArgCtor)
+  }
+
+  @Test def testObjectRuntimeClass(): Unit = {
+    def test(name: String): Unit = {
+      val optClassData = Reflect.lookupLoadableModuleClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      val runtimeClass = optClassData.get.runtimeClass
+      assertEquals(name, name, runtimeClass.getName)
+    }
+
+    test(NameObjectEnableDirect)
+    test(NameObjectEnableIndirect)
+  }
+
+  @Test def testClassCannotBeFound(): Unit = {
+    def test(name: String): Unit =
+      assertTrue(name, Reflect.lookupInstantiatableClass(name).isEmpty)
+
+    test(NameObjectEnableDirect)
+    test(NameTraitEnableDirect)
+    test(NameAbstractClassEnableDirect)
+    test(NameClassNoPublicConstructorEnableDirect)
+    test(NameObjectEnableIndirect)
+    test(NameTraitEnableIndirect)
+    test(NameAbstractClassEnableIndirect)
+    test(NameClassNoPublicConstructorEnableIndirect)
+    test(NameClassDisable)
+    test(NameObjectDisable)
+    test(NameTraitDisable)
+  }
+
+  @Test def testObjectCannotBeFound(): Unit = {
+    def test(name: String): Unit =
+      assertTrue(name, Reflect.lookupLoadableModuleClass(name).isEmpty)
+
+    test(NameClassEnableDirect)
+    test(NameClassEnableDirectNoZeroArgCtor)
+    test(NameTraitEnableDirect)
+    test(NameAbstractClassEnableDirect)
+    test(NameClassNoPublicConstructorEnableDirect)
+    test(NameClassEnableIndirect)
+    test(NameTraitEnableIndirect)
+    test(NameAbstractClassEnableIndirect)
+    test(NameClassNoPublicConstructorEnableIndirect)
+    test(NameClassDisable)
+    test(NameObjectDisable)
+    test(NameTraitDisable)
+  }
+
+  @Test def testClassNoArgCtor(): Unit = {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableIndirect)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      val instance = classData.newInstance().asInstanceOf[Accessors]
+      assertEquals(name, -1, instance.x)
+      assertEquals(name, name.stripPrefix(Prefix), instance.y)
+    }
+  }
+
+  @Test def testClassNoArgCtorErrorCase(): Unit = {
+    for (name <- Seq(NameClassEnableDirectNoZeroArgCtor,
+                     NameClassEnableIndirectNoZeroArgCtor)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      intercept[InstantiationException](classData.newInstance())
+    }
+  }
+
+  @Test def testClassCtorWithArgs(): Unit = {
+    for (name <- Seq(NameClassEnableDirect,
+                     NameClassEnableDirectNoZeroArgCtor,
+                     NameClassEnableIndirect,
+                     NameClassEnableIndirectNoZeroArgCtor)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val optCtorIntString =
+        classData.getConstructor(classOf[Int], classOf[String])
+      assertTrue(optCtorIntString.isDefined)
+      val instanceIntString =
+        optCtorIntString.get.newInstance(543, "foobar").asInstanceOf[Accessors]
+      assertEquals(543, instanceIntString.x)
+      assertEquals("foobar", instanceIntString.y)
+
+      val optCtorInt = classData.getConstructor(classOf[Int])
+      assertTrue(optCtorInt.isDefined)
+      val instanceInt =
+        optCtorInt.get.newInstance(123).asInstanceOf[Accessors]
+      assertEquals(123, instanceInt.x)
+      assertEquals(name.stripPrefix(Prefix), instanceInt.y)
+
+      // Value class is seen as its underlying
+      val optCtorShort = classData.getConstructor(classOf[Short])
+      assertTrue(optCtorShort.isDefined)
+      val instanceShort =
+        optCtorShort.get.newInstance(21.toShort).asInstanceOf[Accessors]
+      assertEquals(42, instanceShort.x)
+      assertEquals(name.stripPrefix(Prefix), instanceShort.y)
+
+      // Non-existent
+      assertFalse(classData.getConstructor(classOf[Boolean]).isDefined)
+      assertFalse(classData.getConstructor(classOf[VC]).isDefined)
+
+      // Non-public
+      assertFalse(classData.getConstructor(classOf[String]).isDefined)
+      assertFalse(classData.getConstructor(classOf[Double]).isDefined)
+    }
+  }
+
+  @Test def testInnerClass(): Unit = {
+    val outer =
+      new ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation(15)
+
+    val optClassData = Reflect.lookupInstantiatableClass(NameInnerClass)
+    assertTrue(optClassData.isDefined)
+    val classData = optClassData.get
+
+    val optCtorOuterString =
+      classData.getConstructor(outer.getClass, classOf[String])
+    assertTrue(optCtorOuterString.isDefined)
+    val instanceOuterString =
+      optCtorOuterString.get.newInstance(outer, "babar").asInstanceOf[Accessors]
+    assertEquals(15, instanceOuterString.x)
+    assertEquals("babar", instanceOuterString.y)
+  }
+
+  private val classInsideLambdaInsideCtor: () => Class[_] = { () =>
+    @EnableReflectiveInstantiation
+    class LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideCtor
+
+    classOf[LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideCtor]
+  }
+
+  @Test def testLocalClass(): Unit = {
+    def assertCannotFind(c: Class[_]): Unit = {
+      val fqcn = c.getName
+      assertFalse(fqcn, Reflect.lookupInstantiatableClass(fqcn).isDefined)
+    }
+
+    // Inside a method
+    @EnableReflectiveInstantiation
+    class LocalClassWithEnableReflectiveInstantiationInsideMethod
+
+    assertCannotFind(
+      classOf[LocalClassWithEnableReflectiveInstantiationInsideMethod])
+
+    assumeFalse(
+      "Scala/JVM 2.10.x does not correctly configure classes in lambdas as local",
+      TestPlatform.isScala210OnJVM)
+
+    // In a lambda whose owner is ultimately the constructor of the class
+    assertCannotFind(classInsideLambdaInsideCtor())
+
+    // Inside lambda whose owner is a method
+    val f = { () =>
+      @EnableReflectiveInstantiation
+      class LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod
+
+      assertCannotFind(
+        classOf[
+          LocalClassWithEnableReflectiveInstantiationInsideLambdaInsideMethod])
+    }
+    f()
+  }
+
+  @Test def testObjectLoad(): Unit = {
+    for (name <- Seq(NameObjectEnableDirect, NameObjectEnableIndirect)) {
+      val optClassData = Reflect.lookupLoadableModuleClass(name)
+      assertTrue(name, optClassData.isDefined)
+      val classData = optClassData.get
+
+      val instance = classData.loadModule().asInstanceOf[Accessors]
+      assertEquals(name, 101, instance.x)
+      assertEquals(name, name.stripPrefix(Prefix), instance.y)
+    }
+  }
+
+  @Test def testObjectLoadInitialization(): Unit = {
+    assertFalse(ReflectTest.ObjectWithInitializationHasBeenInitialized)
+    val optClassData =
+      Reflect.lookupLoadableModuleClass(NameObjectWithInitialization)
+    assertTrue(optClassData.isDefined)
+    val classData = optClassData.get
+    assertFalse(ReflectTest.ObjectWithInitializationHasBeenInitialized)
+
+    classData.loadModule()
+    assertTrue(ReflectTest.ObjectWithInitializationHasBeenInitialized)
+  }
+
+  @Test def testExceptionsInConstructor(): Unit = {
+    val objClassData =
+      Reflect.lookupLoadableModuleClass(NameObjectWithThrowingCtor).get
+    val e1 = intercept[ArithmeticException] {
+      objClassData.loadModule()
+    }
+    assertEquals(ConstructorThrowsMessage, e1.getMessage)
+
+    val clsClassData =
+      Reflect.lookupInstantiatableClass(NameClassWithThrowingCtor).get
+    val e2 = intercept[ArithmeticException] {
+      clsClassData.newInstance()
+    }
+    assertEquals(ConstructorThrowsMessage, e2.getMessage)
+
+    val ctor = clsClassData.getConstructor().get
+    val e3 = intercept[ArithmeticException] {
+      ctor.newInstance()
+    }
+    assertEquals(ConstructorThrowsMessage, e3.getMessage)
+  }
+
+  @Test def testPrivateClass(): Unit = {
+    // Private classes are discoverable
+
+    val optClassData =
+      Reflect.lookupInstantiatableClass(NamePrivateClassEnableDirect)
+    assertTrue("1", optClassData.isDefined)
+    val classData = optClassData.get
+
+    val obj = classData.newInstance()
+    assertEquals("2", "instance of PrivateClassEnableDirect", obj.toString())
+  }
+
+  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228()
+    : Unit = {
+    assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
+    assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
+  }
+
+  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227()
+    : Unit = {
+    // Test that the presence of the following code does not prevent linking
+    val f = { () =>
+      @EnableReflectiveInstantiation
+      class Foo
+    }
+    identity(f) // discard f without compiler warning
+  }
+}
+
+object ReflectTest {
+  private final val ConstructorThrowsMessage = "constructor throws"
+
+  def intercept[T <: Throwable: ClassTag](body: => Unit): T = {
+    try {
+      body
+      throw new AssertionError("no exception was thrown")
+    } catch {
+      case t: T => t
+    }
+  }
+
+  trait Accessors {
+    val x: Int
+    val y: String
+  }
+
+  final class VC(val self: Short) extends AnyVal
+
+  /* FIXME In the classes below, protected constructors are commented out,
+   * because Scala.js and Scala/JVM do not agree on whether they should be
+   * visible. Scala.js says no, but Scala/JVM compiles them as public, and
+   * therefore says yes.
+   */
+
+  // Entities with directly enabled reflection
+
+  @EnableReflectiveInstantiation
+  class ClassEnableDirect(val x: Int, val y: String) extends Accessors {
+    def this(x: Int) = this(x, "ClassEnableDirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassEnableDirectNoZeroArgCtor(val x: Int, val y: String)
+      extends Accessors {
+    def this(x: Int) = this(x, "ClassEnableDirectNoZeroArgCtor")
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  object ObjectEnableDirect extends Accessors {
+    val x = 101
+    val y = "ObjectEnableDirect$"
+  }
+
+  @EnableReflectiveInstantiation
+  trait TraitEnableDirect extends Accessors
+
+  @EnableReflectiveInstantiation
+  abstract class AbstractClassEnableDirect(val x: Int, val y: String)
+      extends Accessors {
+
+    def this(x: Int) = this(x, "AbstractClassEnableDirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassNoPublicConstructorEnableDirect private (val x: Int, val y: String)
+      extends Accessors {
+
+    //protected def this(y: String) = this(-5, y)
+  }
+
+  class ClassWithInnerClassWithEnableReflectiveInstantiation(_x: Int) {
+    @EnableReflectiveInstantiation
+    class InnerClassWithEnableReflectiveInstantiation(_y: String)
+        extends Accessors {
+      val x = _x
+      val y = _y
+    }
+  }
+
+  // Entities with reflection enabled by inheritance
+
+  @EnableReflectiveInstantiation
+  trait EnablingTrait
+
+  class ClassEnableIndirect(val x: Int, val y: String)
+      extends EnablingTrait
+      with Accessors {
+
+    def this(x: Int) = this(x, "ClassEnableIndirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  class ClassEnableIndirectNoZeroArgCtor(val x: Int, val y: String)
+      extends EnablingTrait
+      with Accessors {
+    def this(x: Int) = this(x, "ClassEnableIndirectNoZeroArgCtor")
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  object ObjectEnableIndirect extends EnablingTrait with Accessors {
+    val x = 101
+    val y = "ObjectEnableIndirect$"
+  }
+
+  trait TraitEnableIndirect extends EnablingTrait with Accessors
+
+  abstract class AbstractClassEnableIndirect(val x: Int, val y: String)
+      extends EnablingTrait
+      with Accessors {
+
+    def this(x: Int) = this(x, "AbstractClassEnableIndirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    //protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  class ClassNoPublicConstructorEnableIndirect private (val x: Int,
+                                                        val y: String)
+      extends EnablingTrait
+      with Accessors {
+
+    //protected def this(y: String) = this(-5, y)
+  }
+
+  // Entities with reflection disabled
+
+  class ClassDisable(val x: Int, val y: String) extends Accessors
+
+  object ObjectDisable extends Accessors {
+    val x = 101
+    val y = "ObjectDisable$"
+  }
+
+  trait TraitDisable extends Accessors
+
+  // Corner cases
+
+  var ObjectWithInitializationHasBeenInitialized: Boolean = false
+
+  @EnableReflectiveInstantiation
+  object ObjectWithInitialization {
+    ObjectWithInitializationHasBeenInitialized = true
+  }
+
+  @EnableReflectiveInstantiation
+  object ObjectWithThrowingCtor {
+    throw new ArithmeticException(ConstructorThrowsMessage)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassWithThrowingCtor {
+    throw new ArithmeticException(ConstructorThrowsMessage)
+  }
+
+  // Regression cases
+
+  class ClassWithInnerObjectWithEnableReflectiveInstantiation {
+    @EnableReflectiveInstantiation
+    object InnerObjectWithEnableReflectiveInstantiation
+  }
+}

--- a/native/src/main/scala/org/portablescala/reflect/Reflect.scala
+++ b/native/src/main/scala/org/portablescala/reflect/Reflect.scala
@@ -1,0 +1,81 @@
+package org.portablescala.reflect
+
+import scala.scalanative.reflect.{Reflect => SNReflect}
+
+object Reflect {
+  /** Reflectively looks up a loadable module class.
+   *
+   *  A module class is the technical term referring to the class of a Scala
+   *  `object`. The object or one of its super types (classes or traits) must
+   *  be annotated with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the object must be "static", i.e., declared at the top-level of
+   *  a package or inside a static object.
+   *
+   *  If the module class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was not static, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   */
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
+    SNReflect.lookupLoadableModuleClass(fqcn)
+
+  /** Reflectively looks up a loadable module class.
+   *
+   *  In Scala.js, this method ignores the parameter `loader`. Calling this
+   *  method is equivalent to
+   *  {{{
+   *  Reflect.lookupLoadableModuleClass(fqcn)
+   *  }}}
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   *
+   *  @param loader
+   *    Ignored
+   */
+  def lookupLoadableModuleClass(fqcn: String,
+      loader: ClassLoader): Option[LoadableModuleClass] = {
+    lookupLoadableModuleClass(fqcn)
+  }
+
+  /** Reflectively looks up an instantiable class.
+   *
+   *  The class or one of its super types (classes or traits) must be annotated
+   *  with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the class must not be abstract, nor be a local class (i.e., a
+   *  class defined inside a `def`). Inner classes (defined inside another
+   *  class) are supported.
+   *
+   *  If the class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was abstract or local, this
+   *  method returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   */
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
+    SNReflect.lookupInstantiatableClass(fqcn)
+
+  /** Reflectively looks up an instantiable class.
+   *
+   *  In Scala.js, this method ignores the parameter `loader`. Calling this
+   *  method is equivalent to
+   *  {{{
+   *  Reflect.lookupInstantiatableClass(fqcn)
+   *  }}}
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   *
+   *  @param loader
+   *    Ignored
+   */
+  def lookupInstantiatableClass(fqcn: String,
+      loader: ClassLoader): Option[InstantiatableClass] = {
+    lookupInstantiatableClass(fqcn)
+  }
+}

--- a/native/src/main/scala/org/portablescala/reflect/annotation/package.scala
+++ b/native/src/main/scala/org/portablescala/reflect/annotation/package.scala
@@ -1,0 +1,6 @@
+package org.portablescala.reflect
+
+package object annotation {
+  type EnableReflectiveInstantiation =
+    scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
+}

--- a/native/src/main/scala/org/portablescala/reflect/package.scala
+++ b/native/src/main/scala/org/portablescala/reflect/package.scala
@@ -1,0 +1,9 @@
+package org.portablescala
+
+package object reflect {
+  type InstantiatableClass = scala.scalanative.reflect.InstantiatableClass
+
+  type InvokableConstructor = scala.scalanative.reflect.InvokableConstructor
+
+  type LoadableModuleClass = scala.scalanative.reflect.LoadableModuleClass
+}

--- a/native/src/test/scala/org/portablescala/reflect/TestPlatform.scala
+++ b/native/src/test/scala/org/portablescala/reflect/TestPlatform.scala
@@ -1,0 +1,5 @@
+package org.portablescala.reflect
+
+object TestPlatform {
+  val isScala210OnJVM = false
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,9 @@ val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).filter(_ != "").getOrElse("1.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+
+addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.4.0-SNAPSHOT")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")


### PR DESCRIPTION
This is a first cut, brute force, obvious port of portablescala.reflect
to ScalaNative.  I believe it raises some engineering and/or maintenance
issues which deserve at least a small amount of discussion.

I appreciate kind suggestions & recommendations.  Thank you.

I can not tell if it actually works in Zio because of NIR binary version
issues. The latter probably will need to wait for an 0.4.0-M3 release.

* NB: This PR changes the sbt-scala-js-crossproject from version 0.6.0 to 1.0.0

* Travis CI fails for two reasons. The obvious one is that there is no Scala Native 0.4.0-SNAPSHOT
  version available.  The second is that Travis is looking for the doubly non-extant artifact for 
  scala  2.12.  I had thought I had restricted the build for SN to scala 2.11.12. Obviously what
  I tried did not work.  An opportunity to learn more sbt & cross-project fu. 

* When dust settles, README.md needs to be updated.

* Use of 0.4.0-SNAPSHOT is fragile.:
  1) Devos using SN support need to know to use an 0.4.0-SNAPSHOT
     version. They also need to know that any 0.4.0-M2 libraryDependencies
     used in their project need to be re-built for the 0.4.0-SNAPSHOT
     used.

  2) Perhaps better to wait for 0.4.0-M3 before this is merged?

* Duplication of source, candidate for stream editor

  The code in native is almost identical to the code in js. The former
  was copied from the later and some names were changed to protect the
  innocent.  This leads to the possibility of someone correcting a
  bug on one Platform and forgetting/not_knowing to correct it on the
  other.

  Perhaps others with a greater understanding of scala & sbt can suggest
  a way to avoid/minimize the duplication.

  Normally, I would introduce a build step which ran a stream editor
  to generate the native code from the js code.  That takes some
  extra fussing around here and may be over-kill.

* Duplication of ReflectTest.scala

  I moved & copied ReflectTest.scala from the shared directory to
  the corresponding directories for js & jvm.  The allows "sbt> test"
  and relatives to succeed.  Unfortunately, it introduces the
  duplication I detest.

  To the best of my knowledge, there is no Junit for ScalaNative. In
  other projects I have done the grunt work of manually converting
  the format used by Scala.js to that used by SN.  If needed/recommended,
  I can do that here. I am hesitant because it introduces another variant.
  Perhaps that is a lesser evil than untested code.  At least, Zio will be
  using the code to test Object instantiation.

  With more work than I have time for now, there may be a way to leave
  ReflectTest.scala in shared and adjust the path used by the native
  project to only look in and below native/src/test, skipping shared.
  A bit of a lie about shared but I do not know how to tell cross-project
  that something is shared by only two out of three Platforms. A problem
  for another day.

* build SN & JAVA

  The build shows the same error for both native & jvm.  I took a run
  at figuring it out and failed.  Another problem for another day.
  This does not seem to prevent publishLocal from finishing.

  I am not happy with native having an error, but since it is also
  in the jvm build it is not the greatest defect.
```
/native/src/main/scala/org/portablescala/reflect/Reflect.scala:44:3: Could not find any member to link for "org.portablescala.reflect.annotation.EnableReflectiveInstantiation".
[warn]   /** Reflectively looks up an instantiable class.
[warn]   ^
[warn] native/src/main/scala/org/portablescala/reflect/Reflect.scala:6:3: Could not find any member to link for "org.portablescala.reflect.annotation.EnableReflectiveInstantiation".
[warn]   /** Reflectively looks up a loadable module class.
[warn]   ^
```