### PR TITLE
Update Scala versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: scala
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.10
-  - 2.13.1
+  - 2.12.13
+  - 2.13.4
 jdk:
   - openjdk8
 env:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtcrossproject.{crossProject, CrossType}
 val previousVersion = "1.0.0"
 
 inThisBuild(Def.settings(
-  crossScalaVersions := Seq("2.12.10", "2.10.7", "2.11.12", "2.13.1"),
+  crossScalaVersions := Seq("2.13.4", "2.12.13", "2.11.12", "2.10.7"),
   scalaVersion := crossScalaVersions.value.head,
   version := "1.0.1-SNAPSHOT",
   organization := "org.portable-scala",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.6

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.6
+sbt.version=1.2.8


### PR DESCRIPTION
We update software versions in preparation for adding Scala Native
support. Some Scala.js 0.6.0 special handling is removed.