### PR TITLE
Upgrade Scala.js and Scala version patch levels then add Scala Native support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
 env:
   matrix:
     - SCALAJS_VERSION=
-    - SCALAJS_VERSION=0.6.28
+    - SCALAJS_VERSION=0.6.33
     - SCALAJS_VERSION=1.0.0
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,18 @@ jdk:
   - openjdk8
 env:
   matrix:
-    - SCALAJS_VERSION=
+    - SCALAJVM_VERSION=true
     - SCALAJS_VERSION=0.6.33
     - SCALAJS_VERSION=1.0.0
+    - SCALANATIVE_VERSION=true
 
 script:
   - |
-    if [ "$SCALAJS_VERSION" = "" ]; then
-      PROJECT_NAME="portable-scala-reflectJVM"
-    else
-      PROJECT_NAME="portable-scala-reflectJS"
-    fi
+    [ -v SCALAJVM_VERSION ]    && PROJECT_PLATFORM="JVM"
+    [ -v SCALAJS_VERSION ]     && PROJECT_PLATFORM="JS"
+    [ -v SCALANATIVE_VERSION ] && PROJECT_PLATFORM="Native"
+    PROJECT_NAME="portable-scala-reflect${PROJECT_PLATFORM}"
+
   - sbt ++$TRAVIS_SCALA_VERSION! $PROJECT_NAME/test
   - sbt ++$TRAVIS_SCALA_VERSION! $PROJECT_NAME/doc
   - sbt ++$TRAVIS_SCALA_VERSION! $PROJECT_NAME/mimaReportBinaryIssues

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.10
-  - 2.13.1
+  - 2.12.13
+  - 2.13.4
 jdk:
   - openjdk8
 env:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # portable-scala-reflect: platform-agnostic reflection for Scala
 
 [![Build Status](https://travis-ci.org/portable-scala/portable-scala-reflect.svg?branch=master)](https://travis-ci.org/portable-scala/portable-scala-reflect)
-[![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.29.svg)](https://www.scala-js.org/)
+[![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.33.svg)](https://www.scala-js.org/)
 [![Scala.js](https://www.scala-js.org/assets/badges/scalajs-1.0.0.svg)](https://www.scala-js.org)
 [![Scaladoc](https://javadoc-badge.appspot.com/org.portable-scala/portable-scala-reflect_2.12.svg?label=scaladoc)](https://javadoc.io/doc/org.portable-scala/portable-scala-reflect_2.12/latest/org/portablescala/reflect/index.html)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ libraryDependencies += "org.portable-scala" %%% "portable-scala-reflect" % "1.0.
 * Scala 2.11.x, 2.12.x and 2.13.x
 * Scala/JVM
 * Scala.js 0.6.x and 1.x
+* Scala Native 0.4.x
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ inThisBuild(Def.settings(
     Some("scm:git:git@github.com:portable-scala/portable-scala-reflect.git"))),
 ))
 
-lazy val `portable-scala-reflect` = crossProject(JSPlatform, JVMPlatform)
+lazy val `portable-scala-reflect` = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("."))
   .settings(
     scalacOptions in (Compile, doc) -= "-Xfatal-warnings",
@@ -73,3 +73,10 @@ lazy val `portable-scala-reflect` = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
   )
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
+  .nativeSettings(
+    libraryDependencies +=
+      "org.scala-native" %%% "junit-runtime" % "0.4.0" % "test",
+    addCompilerPlugin(
+      "org.scala-native" % "junit-plugin" % "0.4.0" cross CrossVersion.full),
+    mimaPreviousArtifacts := Set.empty, // SN just added, no previous artifact
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtcrossproject.{crossProject, CrossType}
 val previousVersion = "1.0.0"
 
 inThisBuild(Def.settings(
-  crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1"),
+  crossScalaVersions := Seq("2.12.13", "2.11.12", "2.13.4"),
   scalaVersion := crossScalaVersions.value.head,
   version := "1.1.0-SNAPSHOT",
   organization := "org.portable-scala",

--- a/native/src/main/scala/org/portablescala/reflect/Reflect.scala
+++ b/native/src/main/scala/org/portablescala/reflect/Reflect.scala
@@ -1,0 +1,81 @@
+package org.portablescala.reflect
+
+import scala.scalanative.reflect.{Reflect => ScalaNativeReflect}
+
+object Reflect {
+  /** Reflectively looks up a loadable module class.
+   *
+   *  A module class is the technical term referring to the class of a Scala
+   *  `object`. The object or one of its super types (classes or traits) must
+   *  be annotated with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the object must be "static", i.e., declared at the top-level of
+   *  a package or inside a static object.
+   *
+   *  If the module class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was not static, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   */
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
+    ScalaNativeReflect.lookupLoadableModuleClass(fqcn)
+
+  /** Reflectively looks up a loadable module class.
+   *
+   *  In Scala Native, this method ignores the parameter `loader`. Calling this
+   *  method is equivalent to
+   *  {{{
+   *  Reflect.lookupLoadableModuleClass(fqcn)
+   *  }}}
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   *
+   *  @param loader
+   *    Ignored
+   */
+  def lookupLoadableModuleClass(fqcn: String,
+      loader: ClassLoader): Option[LoadableModuleClass] = {
+    lookupLoadableModuleClass(fqcn)
+  }
+
+  /** Reflectively looks up an instantiable class.
+   *
+   *  The class or one of its super types (classes or traits) must be annotated
+   *  with
+   *  [[org.portablescala.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the class must not be abstract, nor be a local class (i.e., a
+   *  class defined inside a `def`). Inner classes (defined inside another
+   *  class) are supported.
+   *
+   *  If the class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was abstract or local, this
+   *  method returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   */
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
+    ScalaNativeReflect.lookupInstantiatableClass(fqcn)
+
+  /** Reflectively looks up an instantiable class.
+   *
+   *  In Scala Native, this method ignores the parameter `loader`. Calling this
+   *  method is equivalent to
+   *  {{{
+   *  Reflect.lookupInstantiatableClass(fqcn)
+   *  }}}
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   *
+   *  @param loader
+   *    Ignored
+   */
+  def lookupInstantiatableClass(fqcn: String,
+      loader: ClassLoader): Option[InstantiatableClass] = {
+    lookupInstantiatableClass(fqcn)
+  }
+}

--- a/native/src/main/scala/org/portablescala/reflect/annotation/package.scala
+++ b/native/src/main/scala/org/portablescala/reflect/annotation/package.scala
@@ -1,0 +1,6 @@
+package org.portablescala.reflect
+
+package object annotation {
+  type EnableReflectiveInstantiation =
+    scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
+}

--- a/native/src/main/scala/org/portablescala/reflect/package.scala
+++ b/native/src/main/scala/org/portablescala/reflect/package.scala
@@ -1,0 +1,9 @@
+package org.portablescala
+
+package object reflect {
+  type InstantiatableClass = scala.scalanative.reflect.InstantiatableClass
+
+  type InvokableConstructor = scala.scalanative.reflect.InvokableConstructor
+
+  type LoadableModuleClass = scala.scalanative.reflect.LoadableModuleClass
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,7 @@ val scalaJSVersion =
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
+
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")


### PR DESCRIPTION
We first align the Scala.js  & Scala version patch levels to those required by Scala Native
and then add Scala Native support.