### PR TITLE
Upgrade Scala Native to 0.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaversion: ["2.11.12", "2.12.13", "2.13.4"]
+        scalaversion: ["2.12.19", "2.13.13"]
         platform: ["JVM", "JS", "JS-0.6.x", "Native"]
     env:
       SCALAJS_VERSION: "${{ matrix.platform == 'JS-0.6.x' && '0.6.33' || '' }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         scalaversion: ["2.12.19", "2.13.13"]
-        platform: ["JVM", "JS", "JS-0.6.x", "Native"]
+        platform: ["JVM", "JS", "Native"]
     env:
-      SCALAJS_VERSION: "${{ matrix.platform == 'JS-0.6.x' && '0.6.33' || '' }}"
-      PROJECT_NAME: "portable-scala-reflect${{ matrix.platform == 'JS-0.6.x' && 'JS' || matrix.platform }}"
+      PROJECT_NAME: "portable-scala-reflect${{ matrix.platform }}"
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtcrossproject.{crossProject, CrossType}
 val previousVersion = "1.1.2"
 
 inThisBuild(Def.settings(
-  crossScalaVersions := Seq("2.12.13", "2.11.12", "2.13.4"),
+  crossScalaVersions := Seq("2.12.19", "2.13.13"),
   scalaVersion := crossScalaVersions.value.head,
   version := "1.1.3-SNAPSHOT",
   organization := "org.portable-scala",
@@ -76,7 +76,7 @@ lazy val `portable-scala-reflect` = crossProject(JSPlatform, JVMPlatform, Native
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
   .nativeSettings(
     libraryDependencies +=
-      "org.scala-native" %%% "junit-runtime" % "0.4.0" % "test",
+      "org.scala-native" %%% "junit-runtime" % "0.5.1" % "test",
     addCompilerPlugin(
-      "org.scala-native" % "junit-plugin" % "0.4.0" cross CrossVersion.full),
+      "org.scala-native" % "junit-plugin" % "0.5.1" cross CrossVersion.full),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 import com.typesafe.tools.mima.core._
 import sbtcrossproject.{crossProject, CrossType}
 
-val previousVersion = "1.1.2"
+val previousVersion = "1.1.3"
 
 inThisBuild(Def.settings(
   crossScalaVersions := Seq("2.12.19", "2.13.13"),
@@ -30,11 +30,16 @@ inThisBuild(Def.settings(
 lazy val `portable-scala-reflect` = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("."))
   .settings(
-    scalacOptions in (Compile, doc) -= "-Xfatal-warnings",
-
-    mimaPreviousArtifacts +=
-      organization.value %%% moduleName.value % previousVersion,
-
+    Compile / doc /scalacOptions -= "-Xfatal-warnings",
+    mimaPreviousArtifacts := {
+      version.value match {
+        case v if v.startsWith("1.1.3") =>
+          // During migration to Scala Native 0.5.x, ignore the binary compatibility
+          Set.empty
+        case _ =>
+          Set(organization.value %%% moduleName.value % previousVersion)
+      }
+    },
     publishMavenStyle := true,
     publishTo := {
       val nexus = "https://oss.sonatype.org/"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).filter(_ != "").getOrElse("1.0.0")
+  Option(System.getenv("SCALAJS_VERSION")).filter(_ != "").getOrElse("1.16.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.4")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")


### PR DESCRIPTION
Upgrade Scala Native to 0.5.1. 

- Upgrade to sbt 1.9.9 to pass compilation
- [breaking] Dropped Scala 2.11.12, which is no longer supported in Scala Native and Scala.js
- Upgraded sbt-scalajs-crossproject (-native) to the latest version 1.3.2

Ideally, Scala 3 should be supported. However, since the macro-based JVM code needs to be rewritten for Scala 3, it is not included in this PR.