### PR TITLE
Add support for Scala Native 0.5.x.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,16 @@ jobs:
       matrix:
         scalaversion: ["2.11.12", "2.12.13", "2.13.4"]
         platform: ["JVM", "JS", "JS-0.6.x", "Native"]
+        include:
+          # Earliest Scala versions supported by Scala Native 0.5.x
+          - scalaversion: "2.12.14"
+            platform: "Native-0.5.x"
+          - scalaversion: "2.13.8"
+            platform: "Native-0.5.x"
     env:
       SCALAJS_VERSION: "${{ matrix.platform == 'JS-0.6.x' && '0.6.33' || '' }}"
-      PROJECT_NAME: "portable-scala-reflect${{ matrix.platform == 'JS-0.6.x' && 'JS' || matrix.platform }}"
+      SCALANATIVE_VERSION: "${{ matrix.platform == 'Native-0.5.x' && '0.5.2' || '' }}"
+      PROJECT_NAME: "portable-scala-reflect${{ matrix.platform == 'JS-0.6.x' && 'JS' || matrix.platform == 'Native-0.5.x' && 'Native' || matrix.platform }}"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v4
@@ -27,8 +34,8 @@ jobs:
           java-version: "adopt@1.8"
       - uses: coursier/cache-action@v5
       - name: Unit tests
-        run: sbt "++${{ matrix.scalaversion }}" "${{ env.PROJECT_NAME }}/test"
+        run: sbt "++${{ matrix.scalaversion }}!" "${{ env.PROJECT_NAME }}/test"
       - name: Test generate documentation
-        run: sbt "++${{ matrix.scalaversion }}" "${{ env.PROJECT_NAME }}/doc"
+        run: sbt "++${{ matrix.scalaversion }}!" "${{ env.PROJECT_NAME }}/doc"
       - name: MiMa
-        run: sbt "++${{ matrix.scalaversion }}" "${{ env.PROJECT_NAME }}/mimaReportBinaryIssues"
+        run: sbt "++${{ matrix.scalaversion }}!" "${{ env.PROJECT_NAME }}/mimaReportBinaryIssues"

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,14 @@ lazy val `portable-scala-reflect` = crossProject(JSPlatform, JVMPlatform, Native
   .settings(
     scalacOptions in (Compile, doc) -= "-Xfatal-warnings",
 
-    mimaPreviousArtifacts +=
-      organization.value %%% moduleName.value % previousVersion,
+    mimaPreviousArtifacts ++= {
+      val isNewInThisRelease = System.getenv("SCALANATIVE_VERSION") == "0.5.2"
+      if (isNewInThisRelease)
+        Set.empty
+      else
+        Set(organization.value %%% moduleName.value % previousVersion)
+    },
+    mimaFailOnNoPrevious := false,
 
     publishMavenStyle := true,
     publishTo := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,13 @@
 val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).filter(_ != "").getOrElse("1.0.0")
 
+val scalaNativeVersion =
+  Option(System.getenv("SCALANATIVE_VERSION")).filter(_ != "").getOrElse("0.4.4")
+
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.4")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")


### PR DESCRIPTION
Unfortunately, there is no patch Scala version in common between Scala.js 0.6.x and Scala Native 0.5.x. This means we have to force different versions when building for Native 0.5.x.